### PR TITLE
chore: 更新版本号并调整VSCode设置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "livePreview.defaultPreviewPath": "/src/docs/best_section_inline.html"
+}

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -14,7 +14,7 @@ import Notice from '../components/Notice'
 import PageTransitionWrapper from '../components/PageTransitionWrapper'
 
 
-const currentVersion = "25002"
+const currentVersion = "25003"
 
 const version: (keyof typeof versionIds)[] = ["maimai", "GreeN", "ORANGE ", "PiNK", "MURASAKi ", "MiLK", "FiNALE", "舞萌DX", "舞萌DX 2021", "舞萌DX 2022", "舞萌DX 2023", "舞萌DX 2024", "舞萌DX 2025"]
 const versionIds = {

--- a/src/app/tool/best/page.tsx
+++ b/src/app/tool/best/page.tsx
@@ -524,7 +524,7 @@ export default function BestPage() {
                                                     {...song}
                                                     index={index} />
                                             );
-                                        }) : <div className="">暂无数据</div>}
+                                        }) : <div className="">暂无数据</div>} 
                                     </>}
                                     <hr className='w-full mx-auto  border-t-4 border-gray-400 my-5' />
                                 </div>


### PR DESCRIPTION
- 将音乐页面版本号从25002更新至25003
- 添加VSCode默认预览路径配置
- 微调最佳工具页面的空数据提示样式