### PR TITLE
fix: 修正最近更新按钮点击事件调用错误的方法

### DIFF
--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -506,7 +506,7 @@ function CategoryBar({ getSongs, getSongRecentUpdated }: { getSongs: (filteredUr
         <div className=" border-4 border-white bg-pink-400 rounded-full  shadow-lg hover:shadow-2xl hover:scale-105 transition-all duration-300 ease-in-out text-stroke text-stroke-2 text-white">
           <div
             className="max-sm:w-[90px] max-sm:h-10 w-44 h-16 border-4 border-[rgb(247,126,161)] rounded-full bg-white flex justify-center items-center font-bold text-[rgb(255,199,219)] cursor-pointer"
-            onClick={() => getSongs(`version=${currentVersion}`)}
+            onClick={() => getSongRecentUpdated()}
           >
             最近更新
           </div>


### PR DESCRIPTION
将最近更新按钮的点击事件从调用getSongs改为调用getSongRecentUpdated，以正确触发最近更新歌曲的获取功能。