### PR TITLE
fix: 修复CategoryBar组件中未实现的getSongRecentUpdated函数调用

### DIFF
--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -281,9 +281,7 @@ export default function MusicPage() {
               </div>
               <div className="h-[172px]">
                 {/* 根据选择的选项显示不同分类选项 */}
-                {selectedOption === "category" && <CategoryBar getSongs={getSongs} getSongRecentUpdated={function (): Promise<void> {
-                  throw new Error("Function not implemented.")
-                } } />}
+                {selectedOption === "category" && <CategoryBar getSongs={getSongs} getSongRecentUpdated={getSongRecentUpdated} />}
                 {/* {selectedOption === 'aeuio' && <AeuioBar getSongs={getSongs} />} */}
                 {selectedOption === "level" && <LevelBar getSongs={getSongs} />}
                 {selectedOption === "version" && <VersionBar getSongs={getSongs} />}


### PR DESCRIPTION
将硬编码的错误抛出替换为实际传入的getSongRecentUpdated函数，使分类筛选功能正常工作