### PR TITLE
feat: 为所有路由添加默认的Cache-Control头部

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,6 +27,19 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=0, must-revalidate",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 // 使用环境变量控制是否启用打包分析


### PR DESCRIPTION
添加headers配置以设置全局缓存控制策略，防止浏览器缓存静态资源，确保用户始终获取最新内容