### PR TITLE
perf: 禁用 ETag 生成以提升静态资源性能

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,7 @@ const nextConfig = {
   },
   reactStrictMode: false,
   turbopack: {},
+  generateEtags: false,
   images: {
     unoptimized: true,
     remotePatterns: [


### PR DESCRIPTION
禁用 Next.js 的 ETag 生成功能，减少服务器响应头大小，
从而降低网络传输开销并提升静态资源访问速度。